### PR TITLE
[server] return `404` on `DELETE` when there is no ringing or active …

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ curl -X DELETE \
 ```
 **Response:**
 - `204 No Content`: Call terminated
-<!-- - `404 Not Found`: No active call -->
+- `404 Not Found`: No ringing or active call
 - `500 Internal Server Error`: Termination error
 
 ## 🔒 Important Notes

--- a/app/src/main/java/app/callgate/android/modules/server/routes/CallRoutes.kt
+++ b/app/src/main/java/app/callgate/android/modules/server/routes/CallRoutes.kt
@@ -1,6 +1,7 @@
 package app.callgate.android.modules.server.routes
 
 import app.callgate.android.modules.calls.CallsService
+import app.callgate.android.modules.calls.domain.CallState
 import app.callgate.android.modules.server.domain.PostCallsRequest
 import app.callgate.android.modules.server.domain.PostCallsResponse
 import io.ktor.http.HttpStatusCode
@@ -35,6 +36,15 @@ class CallRoutes : KoinComponent {
         }
 
         delete("") {
+            val currentCall = callsService.getCall()
+            if (currentCall.state == CallState.Idle) {
+                call.respond(
+                    HttpStatusCode.NotFound,
+                    mapOf("message" to "No ringing or active call")
+                )
+                return@delete
+            }
+
             if (!callsService.endCall()) {
                 call.respond(HttpStatusCode.InternalServerError, "Failed to end call")
             }


### PR DESCRIPTION
…call

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced the call termination process to verify if an active call exists before attempting to end it, ensuring users are informed when no ongoing call is found.
  - Improved error handling during call termination provides more consistent feedback if the operation is unsuccessful.

- **Documentation**
  - Updated the API documentation for the "End Active Call" endpoint to clarify the conditions for a `404 Not Found` response, specifying "No ringing or active call."
<!-- end of auto-generated comment: release notes by coderabbit.ai -->